### PR TITLE
Add instructions for generating Juspay .pem file in documentation (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,18 @@ REACT_APP_PAYMENT_SERVICE_URL=”PAYMENT_SERVICE_URL”
 
 ```
 
+### Generating the `.pem` File for Juspay Credentials
+
+If you're unable to find the `.pem` file for Juspay credentials, follow these steps:
+
+1. Go to [Juspay Security Settings](https://portal.juspay.in/settings/security).
+2. Under the "RSA Keys" section, click the "Upload new RSA" button on the right.
+3. Select the option "I don't have the RSA Keys, I want to auto-generate the keys."
+4. This will download a file named `private.pem`. Rename this file to `juspay.pem`.
+5. Set the environment variable `JUSPAY_SECRET_KEY_PATH` as:
+   ```bash
+   export JUSPAY_SECRET_KEY_PATH="/PATH/TO/juspay.pem"
+
 **B. Map My India (MMI)**
 
 For location based information, integration with MMI has been used. MMI has been used as follows -


### PR DESCRIPTION
This pull request addresses issue #26 by adding detailed instructions for generating the Juspay .pem file. The steps include navigating to Juspay's portal, generating the RSA keys, downloading the private key as private.pem, and renaming it to juspay.pem. These instructions are added to [specific file, e.g., README.md or a configuration documentation file] to help users set up the JUSPAY_SECRET_KEY_PATH correctly.

Let me know if you need further adjustments!